### PR TITLE
Feature: Retrieve a sleep log from a given date

### DIFF
--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/SleepLogsApiV1.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/SleepLogsApiV1.java
@@ -2,23 +2,37 @@ package com.noom.interview.fullstack.sleep.api.v1;
 
 import com.noom.interview.fullstack.sleep.api.commons.Constants;
 import com.noom.interview.fullstack.sleep.api.v1.requests.CreateSleepLogHttpRequest;
+import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepLogFromSpecificDateHttpResponse;
+import com.noom.interview.fullstack.sleep.infrastructure.validation.ValidDate;
 import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.validation.Valid;
 import java.util.UUID;
 
+@Validated
 public interface SleepLogsApiV1 {
     String BASE_PATH = "sleep-management/api/v1";
     String CREATE_SLEEP_LOG = BASE_PATH + "/sleep-logs";
+    String GET_SLEEP_LOG_FROM_SPECIFIC_DATE = BASE_PATH + "/sleep-logs";
 
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping(CREATE_SLEEP_LOG)
     void createSleepLog(
             @RequestHeader(value = Constants.USER_ID_HEADER) UUID userId,
             @RequestBody @Valid CreateSleepLogHttpRequest request
+    );
+
+    @ResponseStatus(value = HttpStatus.OK)
+    @GetMapping(GET_SLEEP_LOG_FROM_SPECIFIC_DATE)
+    GetSleepLogFromSpecificDateHttpResponse getSleepLogFromSpecificDate(
+            @RequestHeader(value = Constants.USER_ID_HEADER) UUID userId,
+            @RequestParam(value = "date", required = false) @ValidDate(message = "Invalid date. Expected format: yyyy-MM-dd") String date
     );
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/responses/GetSleepLogFromSpecificDateHttpResponse.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/responses/GetSleepLogFromSpecificDateHttpResponse.java
@@ -1,0 +1,14 @@
+package com.noom.interview.fullstack.sleep.api.v1.responses;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GetSleepLogFromSpecificDateHttpResponse {
+    private String date;
+    private String totalSleepTime;
+    private String bedTime;
+    private String wakeUpTime;
+    private String quality;
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/commands/GetSleepLogFromSpecificDateCommand.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/commands/GetSleepLogFromSpecificDateCommand.java
@@ -1,0 +1,16 @@
+package com.noom.interview.fullstack.sleep.application.ports.commands;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class GetSleepLogFromSpecificDateCommand {
+    private UUID userId;
+    private LocalDate date;
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/output/GetSleepLogFromSpecificDateOutput.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/output/GetSleepLogFromSpecificDateOutput.java
@@ -1,5 +1,6 @@
 package com.noom.interview.fullstack.sleep.application.ports.output;
 
+import com.noom.interview.fullstack.sleep.domain.SleepQuality;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,5 +14,5 @@ public class GetSleepLogFromSpecificDateOutput {
     private LocalTime totalSleepTime;
     private LocalTime bedTime;
     private LocalTime wakeUpTime;
-    private String sleepQuality;
+    private SleepQuality sleepQuality;
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/output/GetSleepLogFromSpecificDateOutput.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/output/GetSleepLogFromSpecificDateOutput.java
@@ -1,0 +1,17 @@
+package com.noom.interview.fullstack.sleep.application.ports.output;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class GetSleepLogFromSpecificDateOutput {
+    private LocalDate date;
+    private LocalTime totalSleepTime;
+    private LocalTime bedTime;
+    private LocalTime wakeUpTime;
+    private String sleepQuality;
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/repositories/GetSleepLogFromDateRepository.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/repositories/GetSleepLogFromDateRepository.java
@@ -1,0 +1,11 @@
+package com.noom.interview.fullstack.sleep.application.ports.repositories;
+
+import com.noom.interview.fullstack.sleep.domain.SleepLog;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GetSleepLogFromDateRepository {
+    Optional<SleepLog> findByDate(LocalDate date, UUID userId);
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/usecases/GetSleepLogFromSpecificDateUseCase.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/usecases/GetSleepLogFromSpecificDateUseCase.java
@@ -31,7 +31,7 @@ public class GetSleepLogFromSpecificDateUseCase implements
                         .totalSleepTime(sleepLog.getTotalSleepTimeInBed())
                         .bedTime(sleepLog.getBedTime())
                         .wakeUpTime(sleepLog.getWakeUpTime())
-                        .sleepQuality(sleepLog.getQuality().name())
+                        .sleepQuality(sleepLog.getQuality())
                         .build()
                 )
                 .orElseThrow(() -> new NoLogsForThisDateException(command.getDate()));

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/usecases/GetSleepLogFromSpecificDateUseCase.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/usecases/GetSleepLogFromSpecificDateUseCase.java
@@ -1,0 +1,39 @@
+package com.noom.interview.fullstack.sleep.application.usecases;
+
+import com.noom.interview.fullstack.sleep.application.ports.commands.GetSleepLogFromSpecificDateCommand;
+import com.noom.interview.fullstack.sleep.application.ports.output.GetSleepLogFromSpecificDateOutput;
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetSleepLogFromDateRepository;
+import com.noom.interview.fullstack.sleep.domain.errors.NoLogsForThisDateException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GetSleepLogFromSpecificDateUseCase implements
+        UseCase<GetSleepLogFromSpecificDateCommand, GetSleepLogFromSpecificDateOutput> {
+
+    private final GetSleepLogFromDateRepository getSleepLogFromDateRepository;
+
+    @Override
+    public GetSleepLogFromSpecificDateOutput execute(GetSleepLogFromSpecificDateCommand command) {
+        log.info("Retrieving sleep log for a specific date: userId={}, date={}", command.getUserId(), command.getDate());
+
+        var possibleSleepLog = getSleepLogFromDateRepository.findByDate(
+                command.getDate(),
+                command.getUserId()
+        );
+
+        return possibleSleepLog.map(sleepLog -> GetSleepLogFromSpecificDateOutput.builder()
+                        .date(sleepLog.getSleepDate())
+                        .totalSleepTime(sleepLog.getTotalSleepTimeInBed())
+                        .bedTime(sleepLog.getBedTime())
+                        .wakeUpTime(sleepLog.getWakeUpTime())
+                        .sleepQuality(sleepLog.getQuality().name())
+                        .build()
+                )
+                .orElseThrow(() -> new NoLogsForThisDateException(command.getDate()));
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/errors/NoLogsForThisDateException.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/errors/NoLogsForThisDateException.java
@@ -1,0 +1,11 @@
+package com.noom.interview.fullstack.sleep.domain.errors;
+
+import java.time.LocalDate;
+
+public class NoLogsForThisDateException extends RuntimeException {
+    public NoLogsForThisDateException(LocalDate date) {
+        super(
+            String.format("No sleep logs found for the date: %s", date)
+        );
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/controllers/SleepLogsHttpControllerV1.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/controllers/SleepLogsHttpControllerV1.java
@@ -2,20 +2,26 @@ package com.noom.interview.fullstack.sleep.infrastructure.controllers;
 
 import com.noom.interview.fullstack.sleep.api.v1.SleepLogsApiV1;
 import com.noom.interview.fullstack.sleep.api.v1.requests.CreateSleepLogHttpRequest;
+import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepLogFromSpecificDateHttpResponse;
 import com.noom.interview.fullstack.sleep.application.ports.commands.CreateSleepLogCommand;
+import com.noom.interview.fullstack.sleep.application.ports.commands.GetSleepLogFromSpecificDateCommand;
+import com.noom.interview.fullstack.sleep.application.ports.output.GetSleepLogFromSpecificDateOutput;
 import com.noom.interview.fullstack.sleep.application.usecases.UseCase;
 import com.noom.interview.fullstack.sleep.domain.SleepQuality;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
 public class SleepLogsHttpControllerV1 implements SleepLogsApiV1 {
 
-    private final UseCase<CreateSleepLogCommand, Void> useCase;
+    private final UseCase<CreateSleepLogCommand, Void> createSleepLogUseCase;
+    private final UseCase<GetSleepLogFromSpecificDateCommand, GetSleepLogFromSpecificDateOutput> createSleepLogFromSpecificDateUseCase;
 
     @Override
     public void createSleepLog(UUID userId, CreateSleepLogHttpRequest request) {
@@ -26,6 +32,28 @@ public class SleepLogsHttpControllerV1 implements SleepLogsApiV1 {
                 .quality(SleepQuality.valueOf(request.getQuality()))
                 .build();
 
-        useCase.execute(command);
+        createSleepLogUseCase.execute(command);
+    }
+
+    @Override
+    public GetSleepLogFromSpecificDateHttpResponse getSleepLogFromSpecificDate(UUID userId, String date) {
+        var desiredDate = Optional.ofNullable(date)
+                .map(LocalDate::parse)
+                .orElse(LocalDate.now());
+
+        var command = GetSleepLogFromSpecificDateCommand.builder()
+                .userId(userId)
+                .date(desiredDate)
+                .build();
+
+        var output = createSleepLogFromSpecificDateUseCase.execute(command);
+
+        return GetSleepLogFromSpecificDateHttpResponse.builder()
+                .totalSleepTime(output.getTotalSleepTime().toString())
+                .bedTime(output.getBedTime().toString())
+                .wakeUpTime(output.getWakeUpTime().toString())
+                .quality(output.getSleepQuality().name())
+                .date(output.getDate().toString())
+                .build();
     }
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetSleepLogFromDateRepository.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetSleepLogFromDateRepository.java
@@ -1,0 +1,53 @@
+package com.noom.interview.fullstack.sleep.infrastructure.database;
+
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetSleepLogFromDateRepository;
+import com.noom.interview.fullstack.sleep.domain.SleepLog;
+import com.noom.interview.fullstack.sleep.domain.SleepQuality;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class JdbcGetSleepLogFromDateRepository implements GetSleepLogFromDateRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Override
+    public Optional<SleepLog> findByDate(LocalDate date, UUID userId) {
+        var sql = "SELECT * FROM sleep_logs WHERE user_id = :userId AND sleep_date = :date";
+        var params = Map.of(
+                "userId", userId,
+                "date", date
+        );
+
+        try {
+            var sleepLog = jdbcTemplate.queryForObject(sql, params, (rs, rowNum) -> {
+                var bedTime = rs.getObject("bed_time", LocalTime.class);
+                var wakeUpTime = rs.getObject("wake_up_time", LocalTime.class);
+                var sleepDate = rs.getObject("sleep_date", LocalDate.class);
+                var quality = SleepQuality.valueOf(rs.getString("quality"));
+
+                return SleepLog.builder()
+                        .bedTime(sleepDate.minusDays(1).atTime(bedTime))
+                        .wakeUpTime(sleepDate.atTime(wakeUpTime))
+                        .quality(quality)
+                        .build();
+                    }
+            );
+
+            return Optional.ofNullable(sleepLog);
+        } catch (EmptyResultDataAccessException e) {
+            log.info("No logs found:  userId={}, date={}", userId, date);
+            return Optional.empty();
+        }
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/errorhandlers/GlobalErrorHandler.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/errorhandlers/GlobalErrorHandler.java
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.infrastructure.errorhandlers;
 
 import com.noom.interview.fullstack.sleep.api.v1.responses.ErrorsHttpResponse;
+import com.noom.interview.fullstack.sleep.domain.errors.NoLogsForThisDateException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -8,6 +9,8 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -31,5 +34,22 @@ public class GlobalErrorHandler {
         var errorMessage = String.format("%s header is required. It must be a valid UUID.", exception.getHeaderName());
 
         return new ErrorsHttpResponse(Set.of(errorMessage));
+    }
+
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    @ExceptionHandler(value = NoLogsForThisDateException.class)
+    public ErrorsHttpResponse handleNoLogsForThisDateException(NoLogsForThisDateException exception) {
+        return new ErrorsHttpResponse(Set.of(exception.getMessage()));
+    }
+
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(value = ConstraintViolationException.class)
+    public ErrorsHttpResponse handleConstraintViolationException(ConstraintViolationException exception) {
+        var errors = exception.getConstraintViolations()
+                .stream()
+                .map(ConstraintViolation::getMessage)
+                .collect(Collectors.toSet());
+
+        return new ErrorsHttpResponse(errors);
     }
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/DateValidator.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/DateValidator.java
@@ -1,0 +1,30 @@
+package com.noom.interview.fullstack.sleep.infrastructure.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+public class DateValidator implements ConstraintValidator<ValidDate, String> {
+
+    private boolean allowsNull;
+
+    @Override
+    public void initialize(ValidDate constraintAnnotation) {
+        this.allowsNull = constraintAnnotation.allowsNull();
+    }
+
+    @Override
+    public boolean isValid(String date, ConstraintValidatorContext context) {
+        if (date == null || date.isBlank()) {
+            return allowsNull;
+        }
+
+        try {
+            LocalDate.parse(date, java.time.format.DateTimeFormatter.ISO_LOCAL_DATE);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/ValidDate.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/ValidDate.java
@@ -1,0 +1,20 @@
+package com.noom.interview.fullstack.sleep.infrastructure.validation;
+
+
+import javax.validation.Constraint;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = DateValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+public @interface ValidDate {
+    boolean allowsNull() default true;
+    String message() default "Expected format: yyyy-MM-dd";
+    Class<?>[] groups() default {};
+    Class<? extends javax.validation.Payload>[] payload() default {};
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/usecases/GetSleepLogFromSpecificDateUseCaseTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/usecases/GetSleepLogFromSpecificDateUseCaseTest.groovy
@@ -1,0 +1,65 @@
+package com.noom.interview.fullstack.sleep.application.usecases
+
+import com.noom.interview.fullstack.sleep.application.ports.commands.GetSleepLogFromSpecificDateCommand
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetSleepLogFromDateRepository
+import com.noom.interview.fullstack.sleep.domain.SleepLog
+import com.noom.interview.fullstack.sleep.domain.SleepQuality
+import com.noom.interview.fullstack.sleep.domain.errors.NoLogsForThisDateException
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class GetSleepLogFromSpecificDateUseCaseTest extends Specification {
+
+    def repository = Mock(GetSleepLogFromDateRepository)
+
+    @Subject
+    def useCase = new GetSleepLogFromSpecificDateUseCase(repository)
+
+    def "No logs found for specific date"() {
+        given: "command to get sleep log for a specific date"
+        def command = GetSleepLogFromSpecificDateCommand.builder()
+                .date(LocalDate.now())
+                .userId(UUID.randomUUID())
+                .build()
+
+        and: "there are no logs in the repository for that date related to that user"
+        repository.findByDate(command.date, command.userId) >> Optional.empty()
+
+        when:
+        useCase.execute(command)
+
+        then:
+        thrown(NoLogsForThisDateException)
+    }
+
+    def "Logs found for specific date"() {
+        given: "command to get sleep log for a specific date"
+        def command = GetSleepLogFromSpecificDateCommand.builder()
+                .date(LocalDate.now())
+                .userId(UUID.randomUUID())
+                .build()
+
+        and: "there are logs in the repository for that date related to that user"
+        def sleepTimeInHours = 8
+        def sleepLog = SleepLog.builder()
+                .quality(SleepQuality.GOOD)
+                .bedTime(LocalDateTime.now().minusHours(sleepTimeInHours))
+                .wakeUpTime(LocalDateTime.now())
+                .build()
+
+        repository.findByDate(command.date, command.userId) >> Optional.of(sleepLog)
+
+        when:
+        def result = useCase.execute(command)
+
+        then:
+        result.bedTime == sleepLog.bedTime
+        result.wakeUpTime == sleepLog.wakeUpTime
+        result.sleepQuality == sleepLog.quality.name()
+        result.totalSleepTime == sleepLog.totalSleepTimeInBed
+        result.date == sleepLog.sleepDate
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/usecases/GetSleepLogFromSpecificDateUseCaseTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/usecases/GetSleepLogFromSpecificDateUseCaseTest.groovy
@@ -58,7 +58,7 @@ class GetSleepLogFromSpecificDateUseCaseTest extends Specification {
         then:
         result.bedTime == sleepLog.bedTime
         result.wakeUpTime == sleepLog.wakeUpTime
-        result.sleepQuality == sleepLog.quality.name()
+        result.sleepQuality == sleepLog.quality
         result.totalSleepTime == sleepLog.totalSleepTimeInBed
         result.date == sleepLog.sleepDate
     }

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/controllers/GetSleepLogFromSpecificDateHttpControllerTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/controllers/GetSleepLogFromSpecificDateHttpControllerTest.groovy
@@ -1,0 +1,101 @@
+package com.noom.interview.fullstack.sleep.infrastructure.controllers
+
+import com.noom.interview.fullstack.sleep.api.commons.Constants
+import com.noom.interview.fullstack.sleep.api.v1.SleepLogsApiV1
+import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepLogFromSpecificDateHttpResponse
+import com.noom.interview.fullstack.sleep.application.ports.repositories.SaveSleepLogRepository
+import com.noom.interview.fullstack.sleep.testutils.AbstractControllerTest
+import com.noom.interview.fullstack.sleep.testutils.TestEntitiesBuilder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+
+import java.time.LocalDate
+
+class GetSleepLogFromSpecificDateHttpControllerTest extends AbstractControllerTest {
+
+    @Autowired
+    SaveSleepLogRepository saveSleepLogRepository
+
+    def "Sleep log is not found"() {
+        when: "A user requests a sleep log for a specific date with no logs available"
+        def date = LocalDate.now()
+        def response = createHttpRequest()
+                .with().header(Constants.USER_ID_HEADER, UUID.randomUUID().toString())
+                .and().queryParam("date", date.toString())
+                .when().get(SleepLogsApiV1.GET_SLEEP_LOG_FROM_SPECIFIC_DATE)
+
+        then: "The response contains the correct sleep log data"
+        response.statusCode() == HttpStatus.NOT_FOUND.value()
+
+        and: "response contains a meaningful error message"
+        def responseBody = response.body().asString()
+        responseBody.contains("No sleep logs found")
+        responseBody.contains(date.toString())
+    }
+
+    def "Sleep log is found"() {
+        given: "A user has a sleep log for a specific date"
+        def userId = UUID.randomUUID()
+        def sleepLog = TestEntitiesBuilder.buildSleepLog().build()
+        saveSleepLogRepository.save(sleepLog, userId)
+
+        when: "A user requests a sleep log for that specific date"
+        def response = createHttpRequest()
+                .with().header(Constants.USER_ID_HEADER, userId.toString())
+                .and().queryParam("date", sleepLog.getSleepDate().toString())
+                .when().get(SleepLogsApiV1.GET_SLEEP_LOG_FROM_SPECIFIC_DATE)
+
+        then: "The response status is OK"
+        response.statusCode() == HttpStatus.OK.value()
+
+        and: "sleep log data is returned in the response body"
+        def responseBody = response.body().as(GetSleepLogFromSpecificDateHttpResponse)
+        responseBody.wakeUpTime == sleepLog.wakeUpTime.toString()
+        responseBody.bedTime == sleepLog.bedTime.toString()
+        responseBody.quality == sleepLog.quality.toString()
+        responseBody.date == sleepLog.getSleepDate().toString()
+        responseBody.totalSleepTime == sleepLog.getTotalSleepTimeInBed().toString()
+    }
+
+    def "Defaults to today if no date is provided"() {
+        given: "A user has a sleep log for today"
+        def userId = UUID.randomUUID()
+        def sleepLog = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(LocalDate.now().atStartOfDay().minusHours(3))
+                .wakeUpTime(LocalDate.now().atStartOfDay().plusHours(4))
+                .build()
+        saveSleepLogRepository.save(sleepLog, userId)
+
+        when: "A user requests a sleep log without specifying a date"
+        def response = createHttpRequest()
+                .with().header(Constants.USER_ID_HEADER, userId.toString())
+                .when().get(SleepLogsApiV1.GET_SLEEP_LOG_FROM_SPECIFIC_DATE)
+
+        then: "The response status is OK"
+        response.statusCode() == HttpStatus.OK.value()
+
+        and: "sleep log data is returned in the response body"
+        def responseBody = response.body().as(GetSleepLogFromSpecificDateHttpResponse)
+        responseBody.wakeUpTime == sleepLog.wakeUpTime.toString()
+        responseBody.bedTime == sleepLog.bedTime.toString()
+        responseBody.quality == sleepLog.quality.toString()
+        responseBody.date == LocalDate.now().toString()
+        responseBody.totalSleepTime == sleepLog.getTotalSleepTimeInBed().toString()
+    }
+
+    def "Date is not in correct format"() {
+        when: "A user requests a sleep log with an invalid date format"
+        def response = createHttpRequest()
+                .with().header(Constants.USER_ID_HEADER, UUID.randomUUID().toString())
+                .and().queryParam("date", "invalid-date-format")
+                .when().get(SleepLogsApiV1.GET_SLEEP_LOG_FROM_SPECIFIC_DATE)
+
+        then: "The response status is BAD_REQUEST"
+        response.statusCode() == HttpStatus.BAD_REQUEST.value()
+
+        and: "response contains a meaningful error message"
+        def responseBody = response.body().asString()
+        responseBody.contains("Invalid date")
+        responseBody.contains("yyyy-MM-dd")
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetSleepLogFromSpecificDateRepositoryTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetSleepLogFromSpecificDateRepositoryTest.groovy
@@ -1,0 +1,53 @@
+package com.noom.interview.fullstack.sleep.infrastructure.database
+
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetSleepLogFromDateRepository
+import com.noom.interview.fullstack.sleep.application.ports.repositories.SaveSleepLogRepository
+import com.noom.interview.fullstack.sleep.domain.SleepLog
+import com.noom.interview.fullstack.sleep.domain.SleepQuality
+import com.noom.interview.fullstack.sleep.testutils.AbstractDatabaseTest
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Subject
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class JdbcGetSleepLogFromSpecificDateRepositoryTest extends AbstractDatabaseTest {
+
+    @Autowired
+    SaveSleepLogRepository saveSleepLogRepository
+
+    @Subject
+    @Autowired
+    GetSleepLogFromDateRepository repository
+
+    def "Logs can be retrieved based on user and date"() {
+        given: "a user has a sleep log entry for two days ago"
+        def userId = UUID.randomUUID()
+        def sleepLogForTwoDaysAgo = SleepLog.builder()
+                .bedTime(LocalDateTime.now().minusDays(2).minusHours(8))
+                .wakeUpTime(LocalDateTime.now().minusDays(2))
+                .quality(SleepQuality.GOOD)
+                .build()
+        saveSleepLogRepository.save(sleepLogForTwoDaysAgo, userId)
+
+        when: "we try to get the sleep log for two days ago"
+        def twoDaysAgo = LocalDate.now().minusDays(2)
+        def logFromTwoDaysAgo = repository.findByDate(twoDaysAgo, userId)
+
+        then: "the log is found and matches the expected values"
+        logFromTwoDaysAgo.isPresent()
+
+        and: "the log is correctly populated"
+        def retrievedLog = logFromTwoDaysAgo.get()
+        retrievedLog.bedTime == sleepLogForTwoDaysAgo.bedTime
+        retrievedLog.wakeUpTime == sleepLogForTwoDaysAgo.wakeUpTime
+        retrievedLog.quality == sleepLogForTwoDaysAgo.quality
+
+        when: "we try to get the sleep log for yesterday"
+        def yesterday = LocalDate.now().minusDays(1)
+        def result = repository.findByDate(yesterday, userId)
+
+        then: "no logs are found for that date"
+        result.isEmpty()
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/validation/DateValidatorTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/validation/DateValidatorTest.groovy
@@ -1,0 +1,53 @@
+package com.noom.interview.fullstack.sleep.infrastructure.validation
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+import javax.validation.ConstraintValidatorContext
+
+class DateValidatorTest extends Specification {
+
+    @ValidDate(allowsNull = false)
+    String dateFieldNotNull
+
+    @ValidDate(allowsNull = true)
+    String dateFieldAllowNull
+
+    @Subject
+    DateValidator validator = new DateValidator()
+
+    def "Validate dates and does not accept null or blank strings"() {
+        given:
+        validator.initialize(DateValidatorTest.getDeclaredField("dateFieldNotNull").getAnnotation(ValidDate))
+        ConstraintValidatorContext context = Mock()
+
+        expect:
+        validator.isValid(value, context) == expected
+
+        where:
+        value                   | expected
+        "2024-06-01"    | true
+        null                      | false
+        ""                         | false
+        " "                        | false
+        "invalid"             | false
+    }
+
+    def "Accept null and blank strings"() {
+        given:
+        validator.initialize(DateValidatorTest.getDeclaredField("dateFieldAllowNull")
+                .getAnnotation(ValidDate))
+        ConstraintValidatorContext context = Mock()
+
+        expect:
+        validator.isValid(value, context) == expected
+
+        where:
+        value                   | expected
+        "2024-06-01"    | true
+        null                      | true
+        ""                         | true
+        " "                        | true
+        "invalid"              | false
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/testutils/TestEntitiesBuilder.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/testutils/TestEntitiesBuilder.groovy
@@ -1,0 +1,18 @@
+package com.noom.interview.fullstack.sleep.testutils
+
+import com.noom.interview.fullstack.sleep.domain.SleepLog
+import com.noom.interview.fullstack.sleep.domain.SleepQuality
+
+import java.time.LocalDate
+
+class TestEntitiesBuilder {
+    static SleepLog.SleepLogBuilder buildSleepLog() {
+        def yesterdayNight = LocalDate.now().minusDays(1).atTime(22, 0)
+        def todayMorning = LocalDate.now().atTime(6, 0)
+
+        return SleepLog.builder()
+                .quality(SleepQuality.GOOD)
+                .bedTime(yesterdayNight)
+                .wakeUpTime(todayMorning)
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/testutils/TestRequestsBuilder.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/testutils/TestRequestsBuilder.groovy
@@ -1,6 +1,7 @@
 package com.noom.interview.fullstack.sleep.testutils
 
 import com.noom.interview.fullstack.sleep.api.v1.requests.CreateSleepLogHttpRequest
+import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepLogFromSpecificDateHttpResponse
 import com.noom.interview.fullstack.sleep.domain.SleepQuality
 
 import java.time.LocalDateTime


### PR DESCRIPTION
## This PR introduces the following changes:

Implements REST endpoint: `[GET] /sleep-management/api/v1/sleep-logs`; 

This endpoint retrieves a sleep log for a given date. It behaves as follows:

- Accepts a `date` query parameter in standard ISO format (`yyyy-MM-dd`).
  - If no `date` is provided, the current date is used by default.
- Requires the user's ID to be passed in the `x-user-id` header.
- Responds with the following fields:
  - `date`
  - `bedTime`
  - `wakeUpTime`
  - `quality` — how the user felt upon waking up
  - `totalSleepTime` — total hours of sleep
- Returns a 404 Not Found if no sleep log is found for the specified user and date.