### PR TITLE
Feature: Get sleep summary

### DIFF
--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/SleepLogsApiV1.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/SleepLogsApiV1.java
@@ -3,6 +3,7 @@ package com.noom.interview.fullstack.sleep.api.v1;
 import com.noom.interview.fullstack.sleep.api.commons.Constants;
 import com.noom.interview.fullstack.sleep.api.v1.requests.CreateSleepLogHttpRequest;
 import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepLogFromSpecificDateHttpResponse;
+import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepSummaryHttpResponse;
 import com.noom.interview.fullstack.sleep.infrastructure.validation.ValidDate;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
@@ -21,6 +22,7 @@ public interface SleepLogsApiV1 {
     String BASE_PATH = "sleep-management/api/v1";
     String CREATE_SLEEP_LOG = BASE_PATH + "/sleep-logs";
     String GET_SLEEP_LOG_FROM_SPECIFIC_DATE = BASE_PATH + "/sleep-logs";
+    String GET_SLEEP_SUMMARY = BASE_PATH + "/sleep-logs/summary";
 
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping(CREATE_SLEEP_LOG)
@@ -34,5 +36,13 @@ public interface SleepLogsApiV1 {
     GetSleepLogFromSpecificDateHttpResponse getSleepLogFromSpecificDate(
             @RequestHeader(value = Constants.USER_ID_HEADER) UUID userId,
             @RequestParam(value = "date", required = false) @ValidDate(message = "Invalid date. Expected format: yyyy-MM-dd") String date
+    );
+
+    @ResponseStatus(value = HttpStatus.OK)
+    @GetMapping(GET_SLEEP_SUMMARY)
+    GetSleepSummaryHttpResponse getSleepSummary(
+            @RequestHeader(value = Constants.USER_ID_HEADER) UUID userId,
+            @RequestParam(value = "startDate", required = false) @ValidDate(message = "Invalid startDate. Expected format: yyyy-MM-dd") String startDate,
+            @RequestParam(value = "endDate", required = false) @ValidDate(message = "Invalid endDate. Expected format: yyyy-MM-dd") String endDate
     );
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/responses/GetSleepSummaryHttpResponse.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/responses/GetSleepSummaryHttpResponse.java
@@ -1,0 +1,24 @@
+package com.noom.interview.fullstack.sleep.api.v1.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Builder
+@Getter
+public class GetSleepSummaryHttpResponse {
+    public String averageSleepTime;
+    public String averageBedTime;
+    public String averageWakeUpTime;
+    public Map<String, Integer> sleepQualityFrequency;
+    public Period period;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Period {
+        String startDate;
+        String endDate;
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/commands/GetSleepSummaryCommand.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/commands/GetSleepSummaryCommand.java
@@ -1,0 +1,15 @@
+package com.noom.interview.fullstack.sleep.application.ports.commands;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Builder
+@Getter
+public class GetSleepSummaryCommand {
+    LocalDate startDate;
+    LocalDate endDate;
+    UUID userId;
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/output/GetSleepSummaryOutput.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/output/GetSleepSummaryOutput.java
@@ -1,0 +1,17 @@
+package com.noom.interview.fullstack.sleep.application.ports.output;
+
+import com.noom.interview.fullstack.sleep.domain.SleepQuality;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalTime;
+import java.util.Map;
+
+@Builder
+@Getter
+public class GetSleepSummaryOutput {
+    private LocalTime averageSleepTime;
+    private LocalTime averageBedTime;
+    private LocalTime averageWakeUpTime;
+    private Map<SleepQuality, Integer> sleepQualityFrequency;
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/repositories/GetLogsFromPeriodRepository.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/ports/repositories/GetLogsFromPeriodRepository.java
@@ -1,0 +1,11 @@
+package com.noom.interview.fullstack.sleep.application.ports.repositories;
+
+import com.noom.interview.fullstack.sleep.domain.SleepLog;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface GetLogsFromPeriodRepository {
+    List<SleepLog> findByPeriod(LocalDate startDate, LocalDate endDate, UUID userId);
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/services/AverageTimeCalculator.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/services/AverageTimeCalculator.java
@@ -1,0 +1,18 @@
+package com.noom.interview.fullstack.sleep.application.services;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Service
+public class AverageTimeCalculator {
+    public LocalTime calculateAvgTime(List<LocalTime> times) {
+        var averageInSeconds = times.stream()
+                .mapToLong(LocalTime::toSecondOfDay)
+                .average()
+                .orElse(0L);
+
+        return LocalTime.ofSecondOfDay((long) averageInSeconds);
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/usecases/GetSleepSummaryUseCase.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/usecases/GetSleepSummaryUseCase.java
@@ -1,0 +1,80 @@
+package com.noom.interview.fullstack.sleep.application.usecases;
+
+import com.noom.interview.fullstack.sleep.application.ports.commands.GetSleepSummaryCommand;
+import com.noom.interview.fullstack.sleep.application.ports.output.GetSleepSummaryOutput;
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetLogsFromPeriodRepository;
+import com.noom.interview.fullstack.sleep.application.services.AverageTimeCalculator;
+import com.noom.interview.fullstack.sleep.domain.SleepLog;
+import com.noom.interview.fullstack.sleep.domain.SleepQuality;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GetSleepSummaryUseCase implements
+        UseCase<GetSleepSummaryCommand, GetSleepSummaryOutput>
+{
+
+    private final GetLogsFromPeriodRepository getLogsFromPeriodRepository;
+    private final AverageTimeCalculator averageTimeCalculator;
+
+    @Override
+    public GetSleepSummaryOutput execute(GetSleepSummaryCommand command) {
+        log.info("Retrieving sleep summary: userId={}, from={}, to={}",
+                 command.getUserId(), command.getStartDate(), command.getEndDate());
+
+        var sleepLogs = getLogsFromPeriodRepository.findByPeriod(
+                command.getStartDate(),
+                command.getEndDate(),
+                command.getUserId()
+        );
+
+        var allSleepTimes = sleepLogs.stream()
+                .map(SleepLog::getTotalSleepTimeInBed)
+                .collect(Collectors.toList());
+
+        var allBedTimes = sleepLogs.stream()
+                .map(SleepLog::getBedTime)
+                .collect(Collectors.toList());
+
+        var allWakeUpTimes = sleepLogs.stream()
+                .map(SleepLog::getWakeUpTime)
+                .collect(Collectors.toList());
+
+        var allSleepQualities = sleepLogs.stream()
+                .map(SleepLog::getQuality)
+                .collect(Collectors.toList());
+
+
+        return GetSleepSummaryOutput.builder()
+                .averageBedTime(averageTimeCalculator.calculateAvgTime(allBedTimes))
+                .averageWakeUpTime(averageTimeCalculator.calculateAvgTime(allWakeUpTimes))
+                .averageSleepTime(averageTimeCalculator.calculateAvgTime(allSleepTimes))
+                .sleepQualityFrequency(aggregateSleepQualityCounts(allSleepQualities))
+                .build();
+    }
+
+    private Map<SleepQuality, Integer> aggregateSleepQualityCounts(List<SleepQuality> sleepQualities) {
+        var sleepQualityAggregation = sleepQualities.stream()
+                .collect(Collectors.groupingBy(
+                        quality -> quality,
+                        Collectors.summingInt(quality -> 1)
+                ));
+
+        var qualitiesNotPresentInLogs = Arrays.stream(SleepQuality.values())
+                .filter(sleepQuality -> !sleepQualityAggregation.containsKey(sleepQuality))
+                .collect(Collectors.toList());
+
+        qualitiesNotPresentInLogs.forEach(q -> sleepQualityAggregation.put(q, 0));
+
+        return sleepQualityAggregation;
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/controllers/SleepLogsHttpControllerV1.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/controllers/SleepLogsHttpControllerV1.java
@@ -3,9 +3,12 @@ package com.noom.interview.fullstack.sleep.infrastructure.controllers;
 import com.noom.interview.fullstack.sleep.api.v1.SleepLogsApiV1;
 import com.noom.interview.fullstack.sleep.api.v1.requests.CreateSleepLogHttpRequest;
 import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepLogFromSpecificDateHttpResponse;
+import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepSummaryHttpResponse;
 import com.noom.interview.fullstack.sleep.application.ports.commands.CreateSleepLogCommand;
 import com.noom.interview.fullstack.sleep.application.ports.commands.GetSleepLogFromSpecificDateCommand;
+import com.noom.interview.fullstack.sleep.application.ports.commands.GetSleepSummaryCommand;
 import com.noom.interview.fullstack.sleep.application.ports.output.GetSleepLogFromSpecificDateOutput;
+import com.noom.interview.fullstack.sleep.application.ports.output.GetSleepSummaryOutput;
 import com.noom.interview.fullstack.sleep.application.usecases.UseCase;
 import com.noom.interview.fullstack.sleep.domain.SleepQuality;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepSummaryHttpResponse.Period;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +29,7 @@ public class SleepLogsHttpControllerV1 implements SleepLogsApiV1 {
 
     private final UseCase<CreateSleepLogCommand, Void> createSleepLogUseCase;
     private final UseCase<GetSleepLogFromSpecificDateCommand, GetSleepLogFromSpecificDateOutput> createSleepLogFromSpecificDateUseCase;
+    private final UseCase<GetSleepSummaryCommand, GetSleepSummaryOutput> getSleepSummaryUseCase;
 
     @Override
     public void createSleepLog(UUID userId, CreateSleepLogHttpRequest request) {
@@ -54,6 +62,39 @@ public class SleepLogsHttpControllerV1 implements SleepLogsApiV1 {
                 .wakeUpTime(output.getWakeUpTime().toString())
                 .quality(output.getSleepQuality().name())
                 .date(output.getDate().toString())
+                .build();
+    }
+
+    @Override
+    public GetSleepSummaryHttpResponse getSleepSummary(UUID userId, String startDate, String endDate) {
+        var endDateOrDefault = Optional.ofNullable(endDate)
+                .map(LocalDate::parse)
+                .orElse(LocalDate.now());
+
+        var startDateOrDefault = Optional.ofNullable(startDate)
+                .map(LocalDate::parse)
+                .orElse(endDateOrDefault.minusDays(30));
+
+        var command = GetSleepSummaryCommand.builder()
+                .userId(userId)
+                .startDate(startDateOrDefault)
+                .endDate(endDateOrDefault)
+                .build();
+
+        var output = getSleepSummaryUseCase.execute(command);
+
+        var sleepQualityFrequency = output.getSleepQualityFrequency().entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().name(),
+                        Map.Entry::getValue
+                ));
+
+        return GetSleepSummaryHttpResponse.builder()
+                .averageSleepTime(output.getAverageSleepTime().toString())
+                .averageBedTime(output.getAverageBedTime().toString())
+                .averageWakeUpTime(output.getAverageWakeUpTime().toString())
+                .sleepQualityFrequency(sleepQualityFrequency)
+                .period(new Period(startDateOrDefault.toString(), endDateOrDefault.toString()))
                 .build();
     }
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetLogsFromPeriodRepository.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetLogsFromPeriodRepository.java
@@ -1,0 +1,33 @@
+package com.noom.interview.fullstack.sleep.infrastructure.database;
+
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetLogsFromPeriodRepository;
+import com.noom.interview.fullstack.sleep.domain.SleepLog;
+import com.noom.interview.fullstack.sleep.infrastructure.database.mappers.SleepLogRowMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class JdbcGetLogsFromPeriodRepository implements GetLogsFromPeriodRepository {
+
+    public final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public List<SleepLog> findByPeriod(LocalDate startDate, LocalDate endDate, UUID userId) {
+        var sql = "SELECT * FROM sleep_logs WHERE user_id = :userId AND sleep_date >= :startDate AND sleep_date <= :endDate";
+        var params = Map.of(
+                "userId", userId,
+                "startDate", startDate,
+                "endDate", endDate
+        );
+
+        return jdbcTemplate.query(sql, params, new SleepLogRowMapper());
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetSleepLogFromDateRepository.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetSleepLogFromDateRepository.java
@@ -2,7 +2,7 @@ package com.noom.interview.fullstack.sleep.infrastructure.database;
 
 import com.noom.interview.fullstack.sleep.application.ports.repositories.GetSleepLogFromDateRepository;
 import com.noom.interview.fullstack.sleep.domain.SleepLog;
-import com.noom.interview.fullstack.sleep.domain.SleepQuality;
+import com.noom.interview.fullstack.sleep.infrastructure.database.mappers.SleepLogRowMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.EmptyResultDataAccessException;
@@ -10,7 +10,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -30,19 +29,7 @@ public class JdbcGetSleepLogFromDateRepository implements GetSleepLogFromDateRep
         );
 
         try {
-            var sleepLog = jdbcTemplate.queryForObject(sql, params, (rs, rowNum) -> {
-                var bedTime = rs.getObject("bed_time", LocalTime.class);
-                var wakeUpTime = rs.getObject("wake_up_time", LocalTime.class);
-                var sleepDate = rs.getObject("sleep_date", LocalDate.class);
-                var quality = SleepQuality.valueOf(rs.getString("quality"));
-
-                return SleepLog.builder()
-                        .bedTime(sleepDate.minusDays(1).atTime(bedTime))
-                        .wakeUpTime(sleepDate.atTime(wakeUpTime))
-                        .quality(quality)
-                        .build();
-                    }
-            );
+            var sleepLog = jdbcTemplate.queryForObject(sql, params, new SleepLogRowMapper());
 
             return Optional.ofNullable(sleepLog);
         } catch (EmptyResultDataAccessException e) {

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/mappers/SleepLogRowMapper.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/mappers/SleepLogRowMapper.java
@@ -1,0 +1,27 @@
+package com.noom.interview.fullstack.sleep.infrastructure.database.mappers;
+
+import com.noom.interview.fullstack.sleep.domain.SleepLog;
+import com.noom.interview.fullstack.sleep.domain.SleepQuality;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class SleepLogRowMapper implements RowMapper<SleepLog> {
+
+    @Override
+    public SleepLog mapRow(ResultSet rs, int rowNum) throws SQLException {
+        var bedTime = rs.getObject("bed_time", LocalTime.class);
+        var wakeUpTime = rs.getObject("wake_up_time", LocalTime.class);
+        var sleepDate = rs.getObject("sleep_date", LocalDate.class);
+        var quality = SleepQuality.valueOf(rs.getString("quality"));
+
+        return SleepLog.builder()
+                .bedTime(sleepDate.minusDays(1).atTime(bedTime))
+                .wakeUpTime(sleepDate.atTime(wakeUpTime))
+                .quality(quality)
+                .build();
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/services/AverageTimeCalculatorTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/services/AverageTimeCalculatorTest.groovy
@@ -1,0 +1,30 @@
+package com.noom.interview.fullstack.sleep.application.services
+
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.LocalTime
+
+class AverageTimeCalculatorTest extends Specification {
+
+    @Subject
+    def averageTimeCalculator = new AverageTimeCalculator()
+
+    def "Calculates the average of a list of times"() {
+        when: "a list of times is provided"
+        def average = averageTimeCalculator.calculateAvgTime(times)
+
+        then: "the average time is calculated correctly"
+        average.hour == expected.hour
+        average.minute == expected.minute
+
+        where:
+        expected                     | times
+        LocalTime.of(10, 0)   | [LocalTime.of(10, 0)]
+        LocalTime.of(10, 0)   | [LocalTime.of(10, 0), LocalTime.of(10, 0), LocalTime.of(10, 0)]
+        LocalTime.of(5, 0)     | [LocalTime.of(10, 0), LocalTime.of(0, 0)]
+        LocalTime.of(22, 30) | [LocalTime.of(23, 0), LocalTime.of(22, 0), LocalTime.of(22, 30)]
+        LocalTime.of(7, 15)   | [LocalTime.of(8, 0), LocalTime.of(6, 30), LocalTime.of(7, 15)]
+        LocalTime.of(0, 0)     | []
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/usecases/GetSleepSummaryUseCaseTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/usecases/GetSleepSummaryUseCaseTest.groovy
@@ -1,0 +1,95 @@
+package com.noom.interview.fullstack.sleep.application.usecases
+
+import com.noom.interview.fullstack.sleep.application.ports.commands.GetSleepSummaryCommand
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetLogsFromPeriodRepository
+import com.noom.interview.fullstack.sleep.application.services.AverageTimeCalculator
+import com.noom.interview.fullstack.sleep.domain.SleepQuality
+import com.noom.interview.fullstack.sleep.testutils.TestEntitiesBuilder
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+class GetSleepSummaryUseCaseTest extends Specification {
+
+    def repository = Mock(GetLogsFromPeriodRepository)
+    def averageTimeCalculator = Mock(AverageTimeCalculator)
+
+    @Subject
+    def useCase = new GetSleepSummaryUseCase(repository, averageTimeCalculator)
+
+    def "Retrieves sleep summary for a given period"() {
+        given: "a command to get sleep summary for a specific period"
+        def startDate = LocalDate.now().minusDays(7)
+        def endDate = LocalDate.now()
+        def userId = UUID.randomUUID()
+        def command = GetSleepSummaryCommand.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .userId(userId)
+                .build()
+
+        and: "the user has sleep logs for that period"
+        def sleepLogs = [
+                TestEntitiesBuilder.buildSleepLog().quality(SleepQuality.GOOD).build(),
+                TestEntitiesBuilder.buildSleepLog().quality(SleepQuality.OK).build(),
+                TestEntitiesBuilder.buildSleepLog().quality(SleepQuality.BAD).build(),
+                TestEntitiesBuilder.buildSleepLog().quality(SleepQuality.BAD).build()
+        ]
+        repository.findByPeriod(startDate, endDate, userId) >> sleepLogs
+
+        and: "the average time of sleep  is calculated"
+        def sleepTimes = sleepLogs.collect { it.getTotalSleepTimeInBed() }
+        def averageSleepTime = LocalTime.of(8, 30)
+        1 * averageTimeCalculator.calculateAvgTime(sleepTimes) >> averageSleepTime
+
+        and: "the average wake up time is calculated"
+        def wakeUpTimes = sleepLogs.collect { it.wakeUpTime }
+        def averageWakeUpTime = LocalTime.of(5, 30)
+        1 * averageTimeCalculator.calculateAvgTime(wakeUpTimes) >> averageWakeUpTime
+
+        and: "the average bed time is calculated"
+        def bedTimes = sleepLogs.collect { it.bedTime }
+        def averageBedTime = LocalTime.of(21, 30)
+        1 * averageTimeCalculator.calculateAvgTime(bedTimes) >> averageBedTime
+
+        when:
+        def result = useCase.execute(command)
+
+        then: "the frequency of each sleep quality is calculated correctly"
+        result.sleepQualityFrequency.get(SleepQuality.GOOD) == 1
+        result.sleepQualityFrequency.get(SleepQuality.OK) == 1
+        result.sleepQualityFrequency.get(SleepQuality.BAD) == 2
+
+        and: "the average times are correctly set in the result"
+        result.averageBedTime == averageBedTime
+        result.averageWakeUpTime == averageWakeUpTime
+        result.averageSleepTime == averageSleepTime
+    }
+
+    def "Quality frequency shows zero for quality not present in logs"() {
+        given: "a command to get sleep summary for a specific period"
+        def startDate = LocalDate.now().minusDays(7)
+        def endDate = LocalDate.now()
+        def userId = UUID.randomUUID()
+        def command = GetSleepSummaryCommand.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .userId(userId)
+                .build()
+
+        and: "the user has sleep logs for that period"
+        def sleepLogs = [
+                TestEntitiesBuilder.buildSleepLog().quality(SleepQuality.GOOD).build(),
+                TestEntitiesBuilder.buildSleepLog().quality(SleepQuality.OK).build()
+        ]
+        repository.findByPeriod(startDate, endDate, userId) >> sleepLogs
+
+        when:
+        def result = useCase.execute(command)
+
+        then: "the frequency of BAD quality is zero"
+        result.sleepQualityFrequency.get(SleepQuality.BAD) == 0
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/controllers/GetSleepSummaryControllerTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/controllers/GetSleepSummaryControllerTest.groovy
@@ -1,0 +1,169 @@
+package com.noom.interview.fullstack.sleep.infrastructure.controllers
+
+import com.noom.interview.fullstack.sleep.api.commons.Constants
+import com.noom.interview.fullstack.sleep.api.v1.SleepLogsApiV1
+import com.noom.interview.fullstack.sleep.api.v1.responses.GetSleepSummaryHttpResponse
+import com.noom.interview.fullstack.sleep.application.ports.repositories.SaveSleepLogRepository
+import com.noom.interview.fullstack.sleep.domain.SleepQuality
+import com.noom.interview.fullstack.sleep.testutils.AbstractControllerTest
+import com.noom.interview.fullstack.sleep.testutils.TestEntitiesBuilder
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+class GetSleepSummaryControllerTest extends AbstractControllerTest {
+
+    @Autowired
+    SaveSleepLogRepository saveSleepLogRepository
+
+    def "Field #fieldName is not in correct format"() {
+        when: "A user requests a sleep log with an invalid date format"
+        def response = createHttpRequest()
+                .with().header(Constants.USER_ID_HEADER, UUID.randomUUID().toString())
+                .and().queryParam("startDate", startDate)
+                .and().queryParam("endDate", endDate)
+                .when().get(SleepLogsApiV1.GET_SLEEP_SUMMARY)
+
+        then: "The response status is BAD_REQUEST"
+        response.statusCode() == HttpStatus.BAD_REQUEST.value()
+
+        and: "response contains a meaningful error message"
+        def responseBody = response.body().asString()
+        responseBody.contains(fieldName)
+        responseBody.contains("Invalid")
+        responseBody.contains("yyyy-MM-dd")
+
+        where:
+        fieldName   | startDate        | endDate
+        "startDate" | "202-01-01"    | "2023-01-02"
+        "endDate"   | "2023-01-01" | "202-01-02"
+    }
+
+    def "Retrieve sleep summary for the given period"() {
+        given: "user has some sleep logs in the database"
+        def userId = UUID.randomUUID()
+        def startTime = LocalDate.now().minusDays(7)
+        def endTime = LocalDate.now()
+        def sleepLogOne = TestEntitiesBuilder.buildSleepLog()
+                .quality(SleepQuality.GOOD)
+                .bedTime(startTime.atTime(22, 0))
+                .wakeUpTime(startTime.plusDays(1).atTime(6, 0))
+                .build()
+        def sleepLogTwo = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(endTime.minusDays(1).atTime(22, 0))
+                .quality(SleepQuality.GOOD)
+                .wakeUpTime(endTime.atTime(6, 0))
+                .build()
+
+        saveSleepLogRepository.save(sleepLogOne, userId)
+        saveSleepLogRepository.save(sleepLogTwo, userId)
+
+        when: "requesting sleep summary for the period"
+        def response = createHttpRequest()
+                .with().header(Constants.USER_ID_HEADER, userId.toString())
+                .and().queryParam("startDate", startTime.toString())
+                .and().queryParam("endDate", endTime.toString())
+                .when().get(SleepLogsApiV1.GET_SLEEP_SUMMARY)
+
+        then: "the response status is OK"
+        response.statusCode() == HttpStatus.OK.value()
+
+        and: "the response body contains the correct summary data"
+        def responseBody = response.body().as(GetSleepSummaryHttpResponse)
+        responseBody.averageSleepTime == LocalTime.of(8, 0).toString()
+        responseBody.averageWakeUpTime == LocalTime.of(6, 0).toString()
+        responseBody.averageBedTime == LocalTime.of(22, 0).toString()
+        responseBody.period.startDate == startTime.toString()
+        responseBody.period.endDate == endTime.toString()
+        responseBody.sleepQualityFrequency == [
+                (SleepQuality.GOOD.name()): 2,
+                (SleepQuality.OK.name()): 0,
+                (SleepQuality.BAD.name()): 0,
+        ]
+    }
+
+    def "Defaults to last 30 days"() {
+        given: "user has some sleep logs in the database"
+        def userId = UUID.randomUUID()
+        def startTime = LocalDate.now().minusDays(30)
+        def endTime = LocalDate.now()
+        def sleepLogOne = TestEntitiesBuilder.buildSleepLog()
+                .quality(SleepQuality.GOOD)
+                .bedTime(startTime.minusDays(1).atTime(22, 0))
+                .wakeUpTime(startTime.atTime(6, 0))
+                .build()
+        def sleepLogTwo = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(endTime.minusDays(1).atTime(22, 0))
+                .quality(SleepQuality.GOOD)
+                .wakeUpTime(endTime.atTime(6, 0))
+                .build()
+
+        saveSleepLogRepository.save(sleepLogOne, userId)
+        saveSleepLogRepository.save(sleepLogTwo, userId)
+
+        when: "requesting sleep summary without specifying dates"
+        def response = createHttpRequest()
+                .with().header(Constants.USER_ID_HEADER, userId.toString())
+                .when().get(SleepLogsApiV1.GET_SLEEP_SUMMARY)
+
+        then: "the response status is OK"
+        response.statusCode() == HttpStatus.OK.value()
+
+        and: "the response body contains the correct summary data"
+        def responseBody = response.body().as(GetSleepSummaryHttpResponse)
+        responseBody.averageSleepTime == LocalTime.of(8, 0).toString()
+        responseBody.averageWakeUpTime == LocalTime.of(6, 0).toString()
+        responseBody.averageBedTime == LocalTime.of(22, 0).toString()
+        responseBody.period.startDate == startTime.toString()
+        responseBody.period.endDate == endTime.toString()
+        responseBody.sleepQualityFrequency == [
+                (SleepQuality.GOOD.name()): 2,
+                (SleepQuality.OK.name()): 0,
+                (SleepQuality.BAD.name()): 0,
+        ]
+    }
+
+    def "Start date defaults to 30 days before end date"() {
+        given: "user has some sleep logs in the database"
+        def userId = UUID.randomUUID()
+        def endTime = LocalDate.now().minusDays(30)
+
+        def sleepLogOne = TestEntitiesBuilder.buildSleepLog()
+                .quality(SleepQuality.GOOD)
+                .bedTime(endTime.minusDays(31).atTime(22, 0))
+                .wakeUpTime(endTime.minusDays(30).atTime(6, 0))
+                .build()
+        def sleepLogTwo = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(endTime.minusDays(1).atTime(22, 0))
+                .quality(SleepQuality.GOOD)
+                .wakeUpTime(endTime.atTime(6, 0))
+                .build()
+
+        saveSleepLogRepository.save(sleepLogOne, userId)
+        saveSleepLogRepository.save(sleepLogTwo, userId)
+
+        when: "requesting sleep summary with end date only"
+        def response = createHttpRequest()
+                .with().header(Constants.USER_ID_HEADER, userId.toString())
+                .and().queryParam("endDate", endTime.toString())
+                .when().get(SleepLogsApiV1.GET_SLEEP_SUMMARY)
+
+        then: "the response status is OK"
+        response.statusCode() == HttpStatus.OK.value()
+
+        and: "the response body contains the correct summary data"
+        def responseBody = response.body().as(GetSleepSummaryHttpResponse)
+        responseBody.averageSleepTime == LocalTime.of(8, 0).toString()
+        responseBody.averageWakeUpTime == LocalTime.of(6, 0).toString()
+        responseBody.averageBedTime == LocalTime.of(22, 0).toString()
+        responseBody.period.startDate == endTime.minusDays(30).toString()
+        responseBody.period.endDate == endTime.toString()
+        responseBody.sleepQualityFrequency == [
+                (SleepQuality.GOOD.name()): 2,
+                (SleepQuality.OK.name()): 0,
+                (SleepQuality.BAD.name()): 0,
+        ]
+    }
+}

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetLogsFromPeriodRepositoryTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/database/JdbcGetLogsFromPeriodRepositoryTest.groovy
@@ -1,0 +1,76 @@
+package com.noom.interview.fullstack.sleep.infrastructure.database
+
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetLogsFromPeriodRepository
+import com.noom.interview.fullstack.sleep.application.ports.repositories.SaveSleepLogRepository
+import com.noom.interview.fullstack.sleep.testutils.AbstractDatabaseTest
+import com.noom.interview.fullstack.sleep.testutils.TestEntitiesBuilder
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.Subject
+
+import java.time.LocalDate
+
+class JdbcGetLogsFromPeriodRepositoryTest extends AbstractDatabaseTest {
+
+    @Autowired
+    SaveSleepLogRepository saveSleepLogRepository
+
+    @Subject
+    @Autowired
+    GetLogsFromPeriodRepository getLogsFromPeriodRepository
+
+    def "Retrieve logs from a user for a given period"() {
+        given: "a user has multiple sleep logs for a specific period"
+        def userId = UUID.randomUUID()
+        def startTime = LocalDate.now().minusDays(7)
+        def endTime = LocalDate.now()
+        def sleepLogOne = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(startTime.atTime(22, 0))
+                .wakeUpTime(startTime.plusDays(1).atTime(6, 0))
+                .build()
+        def sleepLogTwo = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(startTime.plusDays(1).atTime(22, 0))
+                .wakeUpTime(startTime.plusDays(2).atTime(6, 0))
+                .build()
+        def sleepLogThree = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(endTime.minusDays(1).atTime(22, 0))
+                .wakeUpTime(endTime.atTime(6, 0))
+                .build()
+
+        saveSleepLogRepository.save(sleepLogOne, userId)
+        saveSleepLogRepository.save(sleepLogTwo, userId)
+        saveSleepLogRepository.save(sleepLogThree, userId)
+
+        when: "we retrieve logs for the specified period"
+        def logs = getLogsFromPeriodRepository.findByPeriod(startTime, endTime, userId)
+
+        then: "the logs are correctly retrieved"
+        logs.size() == 3
+    }
+
+    def "No sleep logs found for a given period"() {
+        given: "a user specifies a period"
+        def userId = UUID.randomUUID()
+        def startTime = LocalDate.now().minusDays(7)
+        def endTime = LocalDate.now()
+
+        and: "their sleep logs are not for that period"
+        def sleepLogOne = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(startTime.minusDays(2).atTime(22, 0))
+                .wakeUpTime(startTime.minusDays(1).atTime(6, 0))
+                .build()
+
+        def sleepLogTwo = TestEntitiesBuilder.buildSleepLog()
+                .bedTime(endTime.atTime(22, 0))
+                .wakeUpTime(endTime.plusDays(1).atTime(6, 0))
+                .build()
+
+        saveSleepLogRepository.save(sleepLogOne, userId)
+        saveSleepLogRepository.save(sleepLogTwo, userId)
+
+        when: "we try to retrieve logs for the specified period"
+        def logs = getLogsFromPeriodRepository.findByPeriod(startTime, endTime, userId)
+
+        then: "no logs are found"
+        logs.isEmpty()
+    }
+}


### PR DESCRIPTION
## This PR introduces the following changes:
Implements REST endpoint: `[GET] /sleep-management/api/v1/sleep-logs/summary`;

This endpoint retrieves the summary of the user's sleep logs for a given period of time. It behaves as follows:
- Accepts a `endDate` query parameter in standard ISO format (`yyyy-MM-dd`).
  - If no `endDate` is provided, the current date is used by default.
- Accepts a `startDate` query parameter in standard ISO format (`yyyy-MM-dd`).
  - If no `startDate` is provided, it defaults to 30 days before the `endDate`.

For instance, if neither startDate nor endDate are provided, the summary of the last 30 days is returned.

### Additional information
- This endpoint requires the user's ID to be passed in the x-user-id header.
- The summary response has the following fields:
  - `averageSleepTime` — Average total time in bed
  - `averageBedTime` — The average time the user gets to bed
  - `averageWakeUpTime` — The average time the user gets out of bed
  - `sleepQualityFrequency` — A map with frequencies of how the user felt in the morning
  - `period` — Period for which the summary is shown