### PR TITLE
Fix/Enhancement: Change date/time input validators to not accept blank strings

### DIFF
--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/SleepLogsApiV1.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/api/v1/SleepLogsApiV1.java
@@ -35,14 +35,14 @@ public interface SleepLogsApiV1 {
     @GetMapping(GET_SLEEP_LOG_FROM_SPECIFIC_DATE)
     GetSleepLogFromSpecificDateHttpResponse getSleepLogFromSpecificDate(
             @RequestHeader(value = Constants.USER_ID_HEADER) UUID userId,
-            @RequestParam(value = "date", required = false) @ValidDate(message = "Invalid date. Expected format: yyyy-MM-dd") String date
+            @RequestParam(value = "date", required = false) @ValidDate(allowsNull = true, message = "Invalid date. Expected format: yyyy-MM-dd") String date
     );
 
     @ResponseStatus(value = HttpStatus.OK)
     @GetMapping(GET_SLEEP_SUMMARY)
     GetSleepSummaryHttpResponse getSleepSummary(
             @RequestHeader(value = Constants.USER_ID_HEADER) UUID userId,
-            @RequestParam(value = "startDate", required = false) @ValidDate(message = "Invalid startDate. Expected format: yyyy-MM-dd") String startDate,
-            @RequestParam(value = "endDate", required = false) @ValidDate(message = "Invalid endDate. Expected format: yyyy-MM-dd") String endDate
+            @RequestParam(value = "startDate", required = false) @ValidDate(allowsNull = true, message = "Invalid startDate. Expected format: yyyy-MM-dd") String startDate,
+            @RequestParam(value = "endDate", required = false) @ValidDate(allowsNull = true, message = "Invalid endDate. Expected format: yyyy-MM-dd") String endDate
     );
 }

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/DateTimeValidator.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/DateTimeValidator.java
@@ -8,10 +8,17 @@ import java.time.format.DateTimeFormatter;
 public class DateTimeValidator implements ConstraintValidator<ValidDateTime, String> {
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
+    private boolean allowsNull;
+
+    @Override
+    public void initialize(ValidDateTime constraintAnnotation) {
+        this.allowsNull = constraintAnnotation.allowsNull();
+    }
+
     @Override
     public boolean isValid(String dateString, ConstraintValidatorContext ctx) {
-        if (dateString == null || dateString.isBlank()) {
-            return false;
+        if (dateString == null) {
+            return allowsNull;
         }
 
         try {

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/DateValidator.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/DateValidator.java
@@ -16,7 +16,7 @@ public class DateValidator implements ConstraintValidator<ValidDate, String> {
 
     @Override
     public boolean isValid(String date, ConstraintValidatorContext context) {
-        if (date == null || date.isBlank()) {
+        if (date == null) {
             return allowsNull;
         }
 

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/ValidDate.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/ValidDate.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.PARAMETER })
 public @interface ValidDate {
-    boolean allowsNull() default true;
+    boolean allowsNull() default false;
     String message() default "Expected format: yyyy-MM-dd";
     Class<?>[] groups() default {};
     Class<? extends javax.validation.Payload>[] payload() default {};

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/ValidDateTime.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/validation/ValidDateTime.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Target;
 @Target({ ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidDateTime {
+    boolean allowsNull() default false;
     String message() default "Expected format: yyyy-MM-dd'T'HH:mm:ss";
     Class<?>[] groups() default {};
     Class<? extends Payload>[] payload() default {};

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/validation/DateTimeValidatorTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/validation/DateTimeValidatorTest.groovy
@@ -3,22 +3,57 @@ package com.noom.interview.fullstack.sleep.infrastructure.validation
 import spock.lang.Specification
 import spock.lang.Subject
 
+import javax.validation.ConstraintValidatorContext
+
 class DateTimeValidatorTest extends Specification {
 
-    @Subject
-    def validator = new DateTimeValidator()
+    @ValidDateTime(allowsNull = false)
+    String dateTimeFieldNotNull
 
-    def "Validates that a date-time string is in ISO-8601 format"() {
+    @ValidDateTime(allowsNull = true)
+    String dateTimeFieldAllowNull
+
+    @Subject
+    DateTimeValidator validator = new DateTimeValidator()
+
+    def "Validate date-times and does not accept null"() {
+        given:
+        validator.initialize(DateTimeValidatorTest.getDeclaredField("dateTimeFieldNotNull").getAnnotation(ValidDateTime))
+        ConstraintValidatorContext context = Mock()
+
         expect:
-        validator.isValid("2023-10-01T12:00:00", null)
-        validator.isValid("2023-10-01T12:00", null)
-        !validator.isValid("2023-10-01T12", null)
-        !validator.isValid("2023-13-01T12:00:00", null)
-        !validator.isValid("2023-06-32T12:00:00", null)
-        !validator.isValid("2023-06-05T26:00:00", null)
-        !validator.isValid("2023-06-05T12:70:00", null)
-        !validator.isValid("2023-06-05T12:30:70", null)
-        !validator.isValid("        ", null)
-        !validator.isValid(null, null)
+        validator.isValid(value, context) == expected
+
+        where:
+        value                                        | expected
+        "2023-10-01T12:00:00"        | true
+        "2023-10-01T12:00"             | true
+        "2023-10-01T12"                   | false
+        "2023-13-01T12:00:00"        | false
+        "2023-06-32T12:00:00"        | false
+        "2023-06-05T26:00:00"        | false
+        "2023-06-05T12:70:00"        | false
+        "2023-06-05T12:30:70"        | false
+        "        "                                      | false
+        null                                           | false
+        ""                                              | false
+        "invalid"                                  | false
+    }
+
+    def "Accept null values"() {
+        given:
+        validator.initialize(DateTimeValidatorTest.getDeclaredField("dateTimeFieldAllowNull").getAnnotation(ValidDateTime))
+        ConstraintValidatorContext context = Mock()
+
+        expect:
+        validator.isValid(value, context) == expected
+
+        where:
+        value                                        | expected
+        "2023-10-01T12:00:00"        | true
+        null                                           | true
+        ""                                              | false
+        "        "                                      | false
+        "invalid"                                  | false
     }
 }

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/validation/DateValidatorTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/validation/DateValidatorTest.groovy
@@ -46,8 +46,8 @@ class DateValidatorTest extends Specification {
         value                   | expected
         "2024-06-01"    | true
         null                      | true
-        ""                         | true
-        " "                        | true
+        ""                         | false
+        " "                        | false
         "invalid"              | false
     }
 }


### PR DESCRIPTION
## This PR introduces the following changes:

- Modifies how date strings received via http requests are validated. Now, empty/blank strings are considered INVALID, preventing parsing issues when processing such requests;
- If a client make request with a blank/empty string date, it results in a 400 (Bad Request).

Null strings are still allow (as long as `allowsNull` is explicitly set to `true`);