### PR TITLE
Fix: Disable multiple sleep logs in a same date

### DIFF
--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/usecases/CreateSleepLogUseCase.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/application/usecases/CreateSleepLogUseCase.java
@@ -1,8 +1,10 @@
 package com.noom.interview.fullstack.sleep.application.usecases;
 
 import com.noom.interview.fullstack.sleep.application.ports.commands.CreateSleepLogCommand;
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetSleepLogFromDateRepository;
 import com.noom.interview.fullstack.sleep.application.ports.repositories.SaveSleepLogRepository;
 import com.noom.interview.fullstack.sleep.domain.SleepLog;
+import com.noom.interview.fullstack.sleep.domain.errors.SleepLogAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,10 +15,21 @@ import org.springframework.stereotype.Service;
 public class CreateSleepLogUseCase implements UseCase<CreateSleepLogCommand, Void> {
 
     private final SaveSleepLogRepository saveSleepLogRepository;
+    private final GetSleepLogFromDateRepository getSleepLogFromDateRepository;
 
     @Override
     public Void execute(CreateSleepLogCommand command) {
         log.info("Creating new sleep log entry: userId={}, date={}", command.getUserId(),  command.getWakeUpTime());
+
+        var isThereSleepLogForDateAlready = getSleepLogFromDateRepository.findByDate(
+                command.getWakeUpTime().toLocalDate(),
+                command.getUserId()
+        ).isPresent();
+
+        if (isThereSleepLogForDateAlready) {
+            log.info("Sleep log already exists for date: userId={}, date={}", command.getUserId(), command.getWakeUpTime());
+            throw new SleepLogAlreadyExistsException(command.getWakeUpTime().toLocalDate());
+        }
 
         var sleepLog = SleepLog.builder()
                 .bedTime(command.getBedTime())

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/errors/SleepLogAlreadyExistsException.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/domain/errors/SleepLogAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.noom.interview.fullstack.sleep.domain.errors;
+
+import java.time.LocalDate;
+
+public class SleepLogAlreadyExistsException extends RuntimeException {
+    public SleepLogAlreadyExistsException(LocalDate date) {
+        super(String.format("Sleep log already exists for date: %s", date));
+    }
+}

--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/errorhandlers/GlobalErrorHandler.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/errorhandlers/GlobalErrorHandler.java
@@ -2,6 +2,7 @@ package com.noom.interview.fullstack.sleep.infrastructure.errorhandlers;
 
 import com.noom.interview.fullstack.sleep.api.v1.responses.ErrorsHttpResponse;
 import com.noom.interview.fullstack.sleep.domain.errors.NoLogsForThisDateException;
+import com.noom.interview.fullstack.sleep.domain.errors.SleepLogAlreadyExistsException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -51,5 +52,11 @@ public class GlobalErrorHandler {
                 .collect(Collectors.toSet());
 
         return new ErrorsHttpResponse(errors);
+    }
+
+    @ResponseStatus(value = HttpStatus.CONFLICT)
+    @ExceptionHandler(value = SleepLogAlreadyExistsException.class)
+    public ErrorsHttpResponse handleSleepLogAlreadyExistsException(SleepLogAlreadyExistsException exception) {
+        return new ErrorsHttpResponse(Set.of(exception.getMessage()));
     }
 }

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/usecases/CreateSleepLogUseCaseTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/application/usecases/CreateSleepLogUseCaseTest.groovy
@@ -1,20 +1,28 @@
 package com.noom.interview.fullstack.sleep.application.usecases
 
 import com.noom.interview.fullstack.sleep.application.ports.commands.CreateSleepLogCommand
+import com.noom.interview.fullstack.sleep.application.ports.repositories.GetSleepLogFromDateRepository
 import com.noom.interview.fullstack.sleep.application.ports.repositories.SaveSleepLogRepository
 import com.noom.interview.fullstack.sleep.domain.SleepLog
 import com.noom.interview.fullstack.sleep.domain.SleepQuality
+import com.noom.interview.fullstack.sleep.domain.errors.SleepLogAlreadyExistsException
+import com.noom.interview.fullstack.sleep.testutils.TestEntitiesBuilder
 import spock.lang.Specification
 import spock.lang.Subject
 
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class CreateSleepLogUseCaseTest extends Specification {
 
     def sleepLogRepository = Mock(SaveSleepLogRepository)
+    def getLogFromSpecificDateRepository = Mock(GetSleepLogFromDateRepository)
 
     @Subject
-    def createSleepLogUseCase = new CreateSleepLogUseCase(sleepLogRepository)
+    def createSleepLogUseCase = new CreateSleepLogUseCase(
+            sleepLogRepository,
+            getLogFromSpecificDateRepository
+    )
 
     def "Create a sleep log and stores it in a repository"() {
         given: "A create sleep log command with valid parameters"
@@ -35,5 +43,26 @@ class CreateSleepLogUseCaseTest extends Specification {
             log.bedTime == command.bedTime.toLocalTime()
             log.wakeUpTime == command.wakeUpTime.toLocalTime()
         }, userId)
+    }
+
+    def "User cannot have more than one log per day"() {
+        given: "A user has an existing sleep log for today"
+        def userId = UUID.randomUUID()
+        getLogFromSpecificDateRepository.findByDate(LocalDate.now(), userId) >>
+                Optional.of(TestEntitiesBuilder.buildSleepLog().build())
+
+        and: "we try to create a new sleep log for today"
+        def command = CreateSleepLogCommand.builder()
+                .bedTime(LocalDateTime.now().minusHours(5))
+                .wakeUpTime(LocalDateTime.now())
+                .quality(SleepQuality.OK)
+                .userId(userId)
+                .build()
+
+        when: "The use case is executed"
+        createSleepLogUseCase.execute(command)
+
+        then: "An exception is thrown indicating the user already has a log for today"
+        thrown(SleepLogAlreadyExistsException)
     }
 }


### PR DESCRIPTION
## Summary
This PR addresses an issue in the sleep log creation process, ensuring that users can only create one sleep log per day as per the requirements.

## Changes
- Enforces the constraint that only a single sleep log per user per day is allowed.
- If a user attempts to create a sleep log for a date that already has an existing entry, the system now responds with a **`409 Conflict`** status code.