### PR TITLE
Fix: Sleep log database mapping when bedtime and wake up time are in the same day

### DIFF
--- a/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/mappers/SleepLogRowMapper.java
+++ b/sleep/src/main/java/com/noom/interview/fullstack/sleep/infrastructure/database/mappers/SleepLogRowMapper.java
@@ -18,10 +18,18 @@ public class SleepLogRowMapper implements RowMapper<SleepLog> {
         var sleepDate = rs.getObject("sleep_date", LocalDate.class);
         var quality = SleepQuality.valueOf(rs.getString("quality"));
 
-        return SleepLog.builder()
-                .bedTime(sleepDate.minusDays(1).atTime(bedTime))
+        var sleepLogBuilder = SleepLog.builder()
                 .wakeUpTime(sleepDate.atTime(wakeUpTime))
-                .quality(quality)
-                .build();
+                .quality(quality);
+
+        var isBedTimeFromPreviousDay = bedTime.isAfter(wakeUpTime);
+
+        if (isBedTimeFromPreviousDay) {
+            sleepLogBuilder.bedTime(sleepDate.minusDays(1).atTime(bedTime));
+        } else {
+            sleepLogBuilder.bedTime(sleepDate.atTime(bedTime));
+        }
+
+        return sleepLogBuilder.build();
     }
 }

--- a/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/database/mappers/SleepLogRowMapperTest.groovy
+++ b/sleep/src/test/groovy/com/noom/interview/fullstack/sleep/infrastructure/database/mappers/SleepLogRowMapperTest.groovy
@@ -1,0 +1,62 @@
+package com.noom.interview.fullstack.sleep.infrastructure.database.mappers
+
+import com.noom.interview.fullstack.sleep.domain.SleepLog
+import com.noom.interview.fullstack.sleep.domain.SleepQuality
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.sql.ResultSet
+import java.time.LocalDate
+import java.time.LocalTime
+
+class SleepLogRowMapperTest extends Specification {
+
+    @Subject
+    def sleepLogRowMapper = new SleepLogRowMapper()
+
+    def "Map result set correctly - Bed time is from day before"() {
+        given:
+        def rs = Mock(ResultSet)
+        def dbBedTime = LocalTime.of(22, 0)
+        def dbWakeUpTime = LocalTime.of(6, 0)
+        def dbSleepDate = LocalDate.of(2024, 6, 10)
+        def dbQuality = SleepQuality.GOOD
+        rs.getObject("bed_time", LocalTime) >> dbBedTime
+        rs.getObject("wake_up_time", LocalTime) >> dbWakeUpTime
+        rs.getObject("sleep_date", LocalDate) >> dbSleepDate
+        rs.getString("quality") >> dbQuality.name()
+
+        when:
+        SleepLog log = sleepLogRowMapper.mapRow(rs, 1)
+
+        then:
+        log.sleepDate == dbSleepDate
+        log.bedTime == dbBedTime
+        log.wakeUpTime == dbWakeUpTime
+        log.quality == SleepQuality.GOOD
+        log.totalSleepTimeInBed == LocalTime.of(8, 0)
+    }
+
+    def "Map result set correctly - Bed time is in the same date as wake up time"() {
+        given:
+        def rs = Mock(ResultSet)
+        def dbBedTime = LocalTime.of(12, 0)
+        def dbWakeUpTime = LocalTime.of(20, 0)
+        def dbSleepDate = LocalDate.of(2024, 6, 10)
+        def dbQuality = SleepQuality.GOOD
+        rs.getObject("bed_time", LocalTime) >> dbBedTime
+        rs.getObject("wake_up_time", LocalTime) >> dbWakeUpTime
+        rs.getObject("sleep_date", LocalDate) >> dbSleepDate
+        rs.getString("quality") >> dbQuality.name()
+
+        when:
+        SleepLog log = sleepLogRowMapper.mapRow(rs, 1)
+
+        then:
+        log.sleepDate == dbSleepDate
+        log.bedTime == dbBedTime
+        log.wakeUpTime == dbWakeUpTime
+        log.quality == SleepQuality.GOOD
+        log.totalSleepTimeInBed == LocalTime.of(8, 0)
+    }
+}


### PR DESCRIPTION
## Summary
This PR addresses an issue in the sleep log retrieving process, where logs with bedtime and wake up time in the same day were throwing exceptions when calculating the total sleep time. Now, the `SleepLogRowMapper` handles the mapping correctly.
